### PR TITLE
servo: fix PWM glitches and run unthrottled at 50Hz

### DIFF
--- a/firmware/Firmware/src/Hardware/timerInit.c
+++ b/firmware/Firmware/src/Hardware/timerInit.c
@@ -92,11 +92,11 @@ void MX_TIM3_Init(void)
     TIM_OC_InitTypeDef sConfigOC = {0};
 
     htim3.Instance = TIM3;
-    htim3.Init.Prescaler = 180 / 2;
+    htim3.Init.Prescaler = 89; // 90MHz / 90 / 20000 = 50Hz
     htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim3.Init.Period = 20000;
     htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-    htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     if (HAL_TIM_PWM_Init(&htim3) != HAL_OK)
     {
         Error_Handler();
@@ -119,6 +119,9 @@ void MX_TIM3_Init(void)
     {
         Error_Handler();
     }
+    // CCR writes are buffered until next update event (no mid-period glitches on rapid servo updates).
+    TIM3->CCMR1 |= TIM_CCMR1_OC2PE;
+    TIM3->CCMR2 |= TIM_CCMR2_OC3PE;
     HAL_TIM_MspPostInit(&htim3);
 }
 
@@ -201,11 +204,11 @@ void MX_TIM9_Init(void)
     TIM_OC_InitTypeDef sConfigOC = {0};
 
     htim9.Instance = TIM9;
-    htim9.Init.Prescaler = 180;
+    htim9.Init.Prescaler = 89; // 90MHz / 90 / 20000 = 50Hz
     htim9.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim9.Init.Period = 20000;
     htim9.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-    htim9.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    htim9.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     if (HAL_TIM_PWM_Init(&htim9) != HAL_OK)
     {
         Error_Handler();
@@ -217,6 +220,9 @@ void MX_TIM9_Init(void)
 
     if (HAL_TIM_PWM_ConfigChannel(&htim9, &sConfigOC, TIM_CHANNEL_1) != HAL_OK) { Error_Handler(); }
     if (HAL_TIM_PWM_ConfigChannel(&htim9, &sConfigOC, TIM_CHANNEL_2) != HAL_OK) { Error_Handler(); }
+
+    // CCR writes are buffered until next update event (no mid-period glitches on rapid servo updates).
+    TIM9->CCMR1 |= TIM_CCMR1_OC1PE | TIM_CCMR1_OC2PE;
 
     HAL_TIM_MspPostInit(&htim9);
 }

--- a/firmware/Firmware/src/main.c
+++ b/firmware/Firmware/src/main.c
@@ -41,7 +41,6 @@
 #include "Storage/flash_cal.h"
 #include "Utillity/utillity.h"
 
-#define SERVO_UPDATE_INTERVAL 100 //ms (only update the servos with 10Hz to avoid servo jitter)
 #define HEARTBEAT_INTERVAL 5000 //ms
 
 /* Private includes ----------------------------------------------------------*/
@@ -103,7 +102,6 @@ int main(void)
     initMotors();
     setupImu();
 
-    uint32_t last_update = HAL_GetTick();
     uint32_t last_heartbeat = HAL_GetTick();
     uint32_t heartbeat_count = 0;
 
@@ -111,11 +109,9 @@ int main(void)
     while (1)
     {
         const uint32_t current_time = HAL_GetTick();
-        if (current_time - last_update >= SERVO_UPDATE_INTERVAL)
-        {
-            update_servo_cmd();
-            last_update = current_time;
-        }
+        // CCR writes are shadowed (OCxPE=1), so the duty cycle the servo sees still
+        // updates only at the start of each 20 ms PWM period regardless of call rate.
+        update_servo_cmd();
 
         if (current_time - last_heartbeat >= HEARTBEAT_INTERVAL)
         {


### PR DESCRIPTION
Enable shadow-register preload (OCxPE + ARPE) on TIM3/TIM9 so CCR writes only take effect at the next update event, eliminating mid-period glitches when servo positions change rapidly.

Fix prescalers so all four servos run at exactly 50Hz: TIM3 was 49.45Hz (PSC=90), TIM9 was 24.86Hz (PSC=180, only ~25Hz frame rate on S2/S3 — likely the main cause of erratic behavior at higher update rates).

Drop the 10Hz SERVO_UPDATE_INTERVAL throttle in main.c — with preload enabled, update_servo_cmd() can now run every loop iteration safely.