### PR TITLE
feat(watchdog): recovery hysteresis + UI shutdown source flag

### DIFF
--- a/include/wombat/services/MotorWatchdog.h
+++ b/include/wombat/services/MotorWatchdog.h
@@ -5,6 +5,7 @@
 namespace wombat
 {
     class DeviceController;
+    class DataPublisher;
 
     /**
      * Hardware safety watchdog driven by heartbeats from raccoon-lib.
@@ -17,6 +18,11 @@ namespace wombat
      *
      * The watchdog is dormant until the first heartbeat is received, so the
      * robot can boot and wait for light without being killed.
+     *
+     * After firing, the watchdog can recover: if `recoverFeeds` heartbeats
+     * arrive in succession (each within `timeout_`), shutdown is cleared. A
+     * gap longer than `timeout_` during recovery resets the counter, so a
+     * single late heartbeat cannot unlatch a still-broken sender.
      */
     class MotorWatchdog
     {
@@ -25,20 +31,30 @@ namespace wombat
         using TimePoint = Clock::time_point;
         using Duration = std::chrono::milliseconds;
 
-        explicit MotorWatchdog(Duration timeout = Duration{500});
+        explicit MotorWatchdog(Duration timeout = Duration{500}, int recoverFeeds = 3);
 
         /// Called by CommandSubscriber on each heartbeat message.
         void feed();
 
-        /// Called every main-loop tick. Fires shutdown if deadline exceeded.
-        void update(DeviceController& controller);
+        /// Called every main-loop tick. Fires shutdown if deadline exceeded,
+        /// or clears it once recovery hysteresis is satisfied. On both
+        /// transitions the shutdown_status channel is updated via the
+        /// publisher so the UI can react independently of any user program.
+        void update(DeviceController& controller, DataPublisher& publisher);
 
         bool hasFired() const { return fired_; }
 
+        /// Drop fired state without touching hardware. Use when the UI manually
+        /// clears a watchdog-triggered shutdown, so the watchdog can re-arm
+        /// and fire again if heartbeats stay missing.
+        void resetAfterManualClear();
+
     private:
         const Duration timeout_;
+        const int recoverFeeds_;
         TimePoint lastFeed_{};
         bool armed_{false};
         bool fired_{false};
+        int recoveryCount_{0};
     };
 } // namespace wombat

--- a/src/wombat/Application.cpp
+++ b/src/wombat/Application.cpp
@@ -336,7 +336,7 @@ namespace wombat
         }
 
         // Update motor watchdog (fires hardware shutdown if heartbeat is missing)
-        motorWatchdog_.update(*deviceController_);
+        motorWatchdog_.update(*deviceController_, *dataPublisher_);
 
         // Update device controller
         auto deviceResult = deviceController_->processUpdate();

--- a/src/wombat/services/CommandSubscriber.cpp
+++ b/src/wombat/services/CommandSubscriber.cpp
@@ -528,8 +528,17 @@ namespace wombat
             return;
         }
 
-        // Publish shutdown status so subscribers (like the UI) can react
-        // Bitmask: bit 0 = servo shutdown, bit 1 = motor shutdown (both enabled/disabled together)
+        // When the user clears a shutdown via the UI, drop any latched
+        // watchdog state so it can re-arm and trigger again if needed.
+        if (!enabled && watchdog_.hasFired())
+        {
+            watchdog_.resetAfterManualClear();
+            logger_->info("Watchdog-triggered shutdown cleared by user — watchdog re-armed");
+        }
+
+        // Publish shutdown status so subscribers (like the UI) can react.
+        // Bitmask: bit 0 = servo shutdown, bit 1 = motor shutdown, bit 2 = source watchdog.
+        // User-initiated commands always clear the source bit.
         const uint8_t shutdownFlags = enabled ? 0x03 : 0x00;
         dataPublisher_->publishShutdownStatus(shutdownFlags);
 

--- a/src/wombat/services/DataPublisher.cpp
+++ b/src/wombat/services/DataPublisher.cpp
@@ -295,7 +295,8 @@ namespace wombat
 
         logger_->info("Published shutdown status: " + std::to_string(shutdownFlags) +
             " (servo=" + (shutdownFlags & 0x01 ? "on" : "off") +
-            ", motor=" + (shutdownFlags & 0x02 ? "on" : "off") + ")");
+            ", motor=" + (shutdownFlags & 0x02 ? "on" : "off") +
+            ", source=" + (shutdownFlags & 0x04 ? "watchdog" : "user") + ")");
 
         return Result<void>::success();
     }

--- a/src/wombat/services/MotorWatchdog.cpp
+++ b/src/wombat/services/MotorWatchdog.cpp
@@ -1,34 +1,89 @@
 #include "wombat/services/MotorWatchdog.h"
+#include "wombat/services/DataPublisher.h"
 #include "wombat/services/DeviceController.h"
 
 #include <cstdio>
 
 namespace wombat
 {
-    MotorWatchdog::MotorWatchdog(Duration timeout)
-        : timeout_{timeout}
+    namespace
+    {
+        // Bitmask published on Channels::SHUTDOWN_STATUS.
+        //   bit 0 (0x01): servo shutdown active
+        //   bit 1 (0x02): motor shutdown active
+        //   bit 2 (0x04): source = watchdog (else: user-initiated)
+        constexpr uint8_t kShutdownClear = 0x00;
+        constexpr uint8_t kShutdownByWatchdog = 0x07;
+    } // namespace
+
+    MotorWatchdog::MotorWatchdog(Duration timeout, int recoverFeeds)
+        : timeout_{timeout}, recoverFeeds_{recoverFeeds}
     {
     }
 
     void MotorWatchdog::feed()
     {
-        lastFeed_ = Clock::now();
+        const auto now = Clock::now();
+
+        if (fired_)
+        {
+            const auto gap = std::chrono::duration_cast<Duration>(now - lastFeed_);
+            if (gap > timeout_)
+                recoveryCount_ = 1;
+            else
+                ++recoveryCount_;
+        }
+
+        lastFeed_ = now;
         armed_ = true;
     }
 
-    void MotorWatchdog::update(DeviceController& controller)
+    void MotorWatchdog::resetAfterManualClear()
     {
-        if (!armed_ || fired_)
+        fired_ = false;
+        recoveryCount_ = 0;
+        // Keep armed_ as-is: if heartbeats had been arriving, the watchdog
+        // stays armed and will re-fire on the next gap. If they never arrived
+        // (armed_ still false), the watchdog stays dormant — same as boot.
+        lastFeed_ = Clock::now();
+    }
+
+    void MotorWatchdog::update(DeviceController& controller, DataPublisher& publisher)
+    {
+        if (!armed_)
             return;
 
         const auto elapsed = std::chrono::duration_cast<Duration>(Clock::now() - lastFeed_);
-        if (elapsed > timeout_)
+
+        if (!fired_)
         {
-            fired_ = true;
+            if (elapsed > timeout_)
+            {
+                fired_ = true;
+                recoveryCount_ = 0;
+                std::fprintf(stderr,
+                    "[watchdog] Heartbeat timeout after %lld ms — setting hardware shutdown\n",
+                    static_cast<long long>(elapsed.count()));
+                controller.setShutdown(true);
+                publisher.publishShutdownStatus(kShutdownByWatchdog);
+            }
+            return;
+        }
+
+        // fired_ == true: handle recovery / reset of stale recovery progress.
+        if (elapsed > timeout_ && recoveryCount_ > 0)
+        {
+            recoveryCount_ = 0;
+        }
+        else if (recoveryCount_ >= recoverFeeds_)
+        {
             std::fprintf(stderr,
-                "[watchdog] Heartbeat timeout after %lld ms — setting hardware shutdown\n",
-                static_cast<long long>(elapsed.count()));
-            controller.setShutdown(true);
+                "[watchdog] Heartbeat recovered (%d consecutive feeds) — clearing hardware shutdown\n",
+                recoveryCount_);
+            fired_ = false;
+            recoveryCount_ = 0;
+            controller.setShutdown(false);
+            publisher.publishShutdownStatus(kShutdownClear);
         }
     }
 } // namespace wombat


### PR DESCRIPTION
Summary

- After firing, the heartbeat watchdog now recovers automatically once 3 consecutive heartbeats arrive within timeout (gaps during recovery reset the counter). Previously the only way out was a service restart.
- SHUTDOWN_STATUS now carries a third bit (0x04 = source watchdog) so the UI can distinguish watchdog-triggered shutdowns from user-initiated ones and offer recovery outside the user program.
- When the user manually clears a watchdog-latched shutdown via SHUTDOWN_CMD, MotorWatchdog::resetAfterManualClear() re-arms the watchdog so it can fire again if heartbeats stay missing.

Context

Hit on hardware during a mission run: a single ~500 ms heartbeat gap (asyncio loop blocked during a parallel SetServoPosition + background launch) latched the firmware shutdown. Motors/servos stopped responding while analog sensors kept working. Python heartbeat is await asyncio.sleep(0.1) in raccoon-lib.

Bitmask now: 0x00 = clear, 0x03 = shutdown active user-initiated, 0x07 = shutdown active watchdog-triggered.

Test plan

- [x] Cross-compile & deploy to Pi - service starts cleanly, no spurious shutdown
- [ ] Trigger watchdog (stop heartbeats), confirm 0x07 published
- [ ] Resume heartbeats, confirm recovery after 3 beats and 0x00 published
- [ ] Confirm a single late beat does not unlatch the shutdown
- [ ] UI receives 0x07 and shows watchdog-specific overlay (see paired botui PR)

Generated with Claude Code