### PR TITLE
feat(logger): publish errors retained so late subscribers see them

### DIFF
--- a/src/wombat/core/Logger.cpp
+++ b/src/wombat/core/Logger.cpp
@@ -69,7 +69,7 @@ namespace wombat
             errorMsg.timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
             errorMsg.value = message;
-            lcmBroker_->publish(Channels::ERROR_MESSAGES, errorMsg);
+            lcmBroker_->publishRetained(Channels::ERROR_MESSAGES, errorMsg);
         }
 
         static spdlog::level::level_enum convertLogLevel(Configuration::Logging::Level level)

--- a/src/wombat/messaging/LcmBroker.cpp
+++ b/src/wombat/messaging/LcmBroker.cpp
@@ -281,6 +281,13 @@ namespace wombat
         return impl_->publishIfChanged(ch, m, retainedOpts);
     }
 
+    template <>
+    Result<void> LcmBroker::publishRetained<raccoon::string_t>(const std::string& ch,
+                                                               const raccoon::string_t& m)
+    {
+        return impl_->publishIfChanged(ch, m, retainedOpts);
+    }
+
     // Explicit template instantiations — subscribe
     template <>
     Result<void> LcmBroker::subscribe<raccoon::vector3f_t>(const std::string& ch,


### PR DESCRIPTION
## Summary
- `Logger::publishErrorToLcm` now calls `LcmBroker::publishRetained` instead of `publish`, so the latest warn/error is cached by the raccoon-transport retain layer.
- Adds the missing `publishRetained<raccoon::string_t>` template instantiation in `LcmBroker.cpp`.
- Pairs with botui PR #7 (`feat/global-error-modal`), which subscribes to `raccoon/errors` with `requestRetained: true`. Together this means a late-starting UI replays the last error and shows the Acknowledge modal.

## Test plan
- [ ] Deploy with `./deploy.sh`.
- [ ] Restart the reader, trigger a known error (e.g. force a publish failure), then restart the botui after the error has fired.
- [ ] Verify the UI shows the cached error in the Acknowledge modal at startup.
- [ ] Verify subsequent errors keep appearing in real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)