### PR TITLE
fix(watchdog): drop to dormant state on manual recovery

### DIFF
--- a/src/wombat/services/MotorWatchdog.cpp
+++ b/src/wombat/services/MotorWatchdog.cpp
@@ -42,10 +42,10 @@ namespace wombat
     {
         fired_ = false;
         recoveryCount_ = 0;
-        // Keep armed_ as-is: if heartbeats had been arriving, the watchdog
-        // stays armed and will re-fire on the next gap. If they never arrived
-        // (armed_ still false), the watchdog stays dormant — same as boot.
-        lastFeed_ = Clock::now();
+        // Drop back to boot-like dormant state: the user cleared the shutdown
+        // explicitly, presumably because no program is running. The watchdog
+        // re-arms automatically on the next heartbeat via feed().
+        armed_ = false;
     }
 
     void MotorWatchdog::update(DeviceController& controller, DataPublisher& publisher)


### PR DESCRIPTION
Summary

Follow-up to #12. Discovered on hardware: pressing Recover in the UI cleared the shutdown but the watchdog re-fired ~500 ms later because resetAfterManualClear() kept armed_ = true and no heartbeats were arriving (the user program is not running — that is why the user pressed Recover).

Fix: disarm on manual clear. Same state as boot. The watchdog re-arms automatically on the next heartbeat via feed(), so starting a mission restores normal armed behavior.

Reader log before the fix:
- Watchdog-triggered shutdown cleared by user — watchdog re-armed
- Published shutdown status: 0
- Shutdown disabled
- [watchdog] Heartbeat timeout after 509 ms — setting hardware shutdown
- Published shutdown status: 7

Test plan

- [x] Cross-compile and deploy to Pi
- [ ] Trigger watchdog, press Recover in UI — overlay stays gone with no user program running
- [ ] Start a mission, verify watchdog arms and fires as expected when heartbeats stop

Generated with Claude Code