### PR TITLE
Fix GitHub Actions runner for firmware release build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-firmware:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
           path: firmware-out/*
 
   build-reader:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 
@@ -40,7 +40,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.GH_PAT }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build ARM64 binary
         run: |
@@ -56,7 +61,7 @@ jobs:
 
   release:
     needs: [ build-firmware, build-reader ]
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "raccoon-transport"]
 	path = raccoon-transport
-	url = git@github.com:htl-stp-ecer/raccoon-transport.git
+	url = https://github.com/htl-stp-ecer/raccoon-transport.git


### PR DESCRIPTION
## Summary
- move the release workflow off the failing self-hosted runner onto GitHub-hosted Ubuntu
- set up QEMU and Buildx for the ARM64 reader build
- use HTTPS for the public raccoon-transport submodule so recursive checkout works on hosted runners

## Why
The current firmware job on main failed on the self-hosted Macmini runner, while the firmware build reproduces successfully in a clean environment. This change removes the runner-specific failure path and keeps the release workflow working on a public repo.
