### PR TITLE
Run ARM64 reader build on native hosted runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,7 +31,7 @@ jobs:
           path: firmware-out/*
 
   build-reader:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
 
@@ -40,12 +40,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build ARM64 binary
         run: |


### PR DESCRIPTION
## Summary
- move the reader build from x64 emulation to the native GitHub-hosted ARM runner
- drop QEMU and Buildx setup from that job

## Why
Run #50 shows the firmware job succeeding on GitHub-hosted Ubuntu, but the reader build remains stuck in the emulated ARM64 build step. GitHub documents native Linux arm64 hosted runners for public repositories via `ubuntu-24.04-arm`, which should remove the emulation bottleneck.
